### PR TITLE
remove a test case with incorrect caption (swap-obj, id 108)

### DIFF
--- a/data/swap_obj.json
+++ b/data/swap_obj.json
@@ -539,11 +539,6 @@
         "caption": "a girl holds a baby eating a bagel with a boy standing next to them",
         "negative_caption": "A boy holds a baby eating a bagel with a girl standing next to them."
     },
-    "108": {
-        "filename": "000000310622.jpg",
-        "caption": "A West 32nd sign under a Korea Way road sign. ",
-        "negative_caption": "A Korea Way sign under a West 32nd road sign."
-    },
     "109": {
         "filename": "000000007816.jpg",
         "caption": "A person on a motorcycles driving past a group of people behind a fence.",

--- a/data_unrefined/swap_obj.json
+++ b/data_unrefined/swap_obj.json
@@ -94,11 +94,6 @@
         "caption": "A jockey rides a horse in a field",
         "negative_caption": "A horse rides a jockey in a field."
     },
-    "19": {
-        "filename": "000000310622.jpg",
-        "caption": "A West 32nd sign under a Korea Way road sign. ",
-        "negative_caption": "A Korea Way sign under a West 32nd road sign."
-    },
     "20": {
         "filename": "000000483531.jpg",
         "caption": "Two twin beds in a room with a picture of flowers above it.",


### PR DESCRIPTION
There is one test case in coco-caption 2017 whose caption is incorrect, we decided to remove this test case from SugarCrepe

Image: http://images.cocodataset.org/val2017/000000310622.jpg

![image](https://github.com/RAIVNLab/sugar-crepe/assets/32179244/719b397c-1efb-486f-9c2a-5cc4a48f5a57)


Positive caption: `A West 32nd sign under a Korea Way road sign.` 

The correct caption should be `A West 32nd sign above a Korea Way road sign.` 